### PR TITLE
Unnecessary buffers Patch

### DIFF
--- a/jQuery-File-Upload.MVC3/Controllers/HomeController.cs
+++ b/jQuery-File-Upload.MVC3/Controllers/HomeController.cs
@@ -97,7 +97,7 @@ namespace jQuery_File_Upload.MVC3.Controllers
 
             using (var fs = new FileStream(fullName, FileMode.Append, FileAccess.Write))
             {
-                file.InputStream.CopyTo(files);
+                file.InputStream.CopyTo(fs);
             }
             
             statuses.Add(new ViewDataUploadFilesResult()

--- a/jQuery-File-Upload.MVC3/Controllers/HomeController.cs
+++ b/jQuery-File-Upload.MVC3/Controllers/HomeController.cs
@@ -91,24 +91,15 @@ namespace jQuery_File_Upload.MVC3.Controllers
         private void UploadPartialFile(string fileName, HttpRequestBase request, List<ViewDataUploadFilesResult> statuses)
         {
             if (request.Files.Count != 1) throw new HttpRequestValidationException("Attempt to upload chunked file containing more than one fragment per request");
-            var file = request.Files[0];
-            var inputStream = file.InputStream;
 
+            var file = request.Files[0];
             var fullName = Path.Combine(StorageRoot, Path.GetFileName(fileName));
 
             using (var fs = new FileStream(fullName, FileMode.Append, FileAccess.Write))
             {
-                var buffer = new byte[1024];
-
-                var l = inputStream.Read(buffer, 0, 1024);
-                while (l > 0)
-                {
-                    fs.Write(buffer, 0, l);
-                    l = inputStream.Read(buffer, 0, 1024);
-                }
-                fs.Flush();
-                fs.Close();
+                file.InputStream.CopyTo(files);
             }
+            
             statuses.Add(new ViewDataUploadFilesResult()
             {
                 name = fileName,

--- a/jQuery-File-Upload.MVC3/Upload/UploadHandler.ashx.cs
+++ b/jQuery-File-Upload.MVC3/Upload/UploadHandler.ashx.cs
@@ -108,16 +108,7 @@ namespace jQuery_File_Upload.MVC3.Upload
 
             using (var fs = new FileStream(fullName, FileMode.Append, FileAccess.Write))
             {
-                var buffer = new byte[1024];
-
-                var l = inputStream.Read(buffer, 0, 1024);
-                while (l > 0)
-                {
-                    fs.Write(buffer, 0, l);
-                    l = inputStream.Read(buffer, 0, 1024);
-                }
-                fs.Flush();
-                fs.Close();
+                inputStream.CopyTo(fs);
             }
             statuses.Add(new FilesStatus(new FileInfo(fullName)));
         }


### PR DESCRIPTION
Removed buffers in partial upload of files because they are unnecessary and can sometimes cause outOfMemory exceptions.
